### PR TITLE
fix: request Shizuku permissions only when necessary

### DIFF
--- a/app/src/main/java/dev/beefers/vendetta/manager/installer/shizuku/ShizukuInstaller.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/installer/shizuku/ShizukuInstaller.kt
@@ -10,6 +10,7 @@ import rikka.shizuku.Shizuku
 import java.io.File
 
 class ShizukuInstaller(private val context: Context) : Installer {
+
     override suspend fun installApks(silent: Boolean, vararg apks: File) {
         if (!ShizukuPermissions.waitShizukuPermissions()) {
             withContext(Dispatchers.Main) {

--- a/app/src/main/java/dev/beefers/vendetta/manager/installer/shizuku/ShizukuPermissions.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/installer/shizuku/ShizukuPermissions.kt
@@ -1,0 +1,49 @@
+package dev.beefers.vendetta.manager.installer.shizuku
+
+import android.content.pm.PackageManager
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import rikka.shizuku.Shizuku
+import rikka.shizuku.Shizuku.OnRequestPermissionResultListener
+
+@OptIn(DelicateCoroutinesApi::class)
+object ShizukuPermissions {
+    private const val REQUEST_CODE = 1
+
+    private val _permissionsGranted = MutableSharedFlow<Boolean>(replay = 0)
+    private lateinit var permissionResultListener: OnRequestPermissionResultListener
+
+    fun requestShizukuPermissions() {
+        if (!Shizuku.pingBinder()) {
+            GlobalScope.launch { _permissionsGranted.emit(false) }
+            return
+        }
+        if (Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED) {
+            GlobalScope.launch { _permissionsGranted.emit(true) }
+            return
+        }
+
+        Shizuku.addRequestPermissionResultListener(permissionResultListener)
+        Shizuku.requestPermission(REQUEST_CODE)
+    }
+
+    suspend fun waitShizukuPermissions(): Boolean {
+        requestShizukuPermissions()
+        return _permissionsGranted.first()
+    }
+
+    init {
+        permissionResultListener = OnRequestPermissionResultListener { requestCode, grantResult ->
+            if (requestCode != REQUEST_CODE) return@OnRequestPermissionResultListener
+
+            Shizuku.removeRequestPermissionResultListener(permissionResultListener)
+
+            GlobalScope.launch {
+                _permissionsGranted.emit(grantResult == PackageManager.PERMISSION_GRANTED)
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/beefers/vendetta/manager/installer/shizuku/ShizukuPermissions.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/installer/shizuku/ShizukuPermissions.kt
@@ -11,6 +11,7 @@ import rikka.shizuku.Shizuku.OnRequestPermissionResultListener
 
 @OptIn(DelicateCoroutinesApi::class)
 object ShizukuPermissions {
+
     private const val REQUEST_CODE = 1
 
     private val _permissionsGranted = MutableSharedFlow<Boolean>(replay = 0)
@@ -46,4 +47,5 @@ object ShizukuPermissions {
             }
         }
     }
+
 }

--- a/app/src/main/java/dev/beefers/vendetta/manager/ui/activity/MainActivity.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/ui/activity/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.core.app.ActivityCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.lifecycleScope
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.transitions.SlideTransition
 import dev.beefers.vendetta.manager.domain.manager.InstallMethod
@@ -18,6 +19,7 @@ import dev.beefers.vendetta.manager.ui.screen.main.MainScreen
 import dev.beefers.vendetta.manager.ui.theme.VendettaManagerTheme
 import dev.beefers.vendetta.manager.utils.DiscordVersion
 import dev.beefers.vendetta.manager.utils.Intents
+import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 
 class MainActivity : ComponentActivity() {
@@ -38,8 +40,13 @@ class MainActivity : ComponentActivity() {
             )
         }
 
-        if (preferences.installMethod == InstallMethod.SHIZUKU)
-            ShizukuPermissions.requestShizukuPermissions()
+        if (preferences.installMethod == InstallMethod.SHIZUKU) {
+            lifecycleScope.launch {
+                if (!ShizukuPermissions.waitShizukuPermissions()) {
+                    preferences.installMethod = InstallMethod.DEFAULT
+                }
+            }
+        }
 
         val screen = if (intent.action == Intents.Actions.INSTALL && version != null) {
             InstallerScreen(DiscordVersion.fromVersionCode(version)!!)

--- a/app/src/main/java/dev/beefers/vendetta/manager/ui/activity/MainActivity.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/ui/activity/MainActivity.kt
@@ -21,6 +21,7 @@ import dev.beefers.vendetta.manager.utils.Intents
 import org.koin.android.ext.android.inject
 
 class MainActivity : ComponentActivity() {
+
     private val preferences: PreferenceManager by inject()
 
     @OptIn(ExperimentalAnimationApi::class)
@@ -54,4 +55,5 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
+
 }

--- a/app/src/main/java/dev/beefers/vendetta/manager/ui/activity/MainActivity.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/ui/activity/MainActivity.kt
@@ -10,33 +10,18 @@ import androidx.core.app.ActivityCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.transitions.SlideTransition
+import dev.beefers.vendetta.manager.domain.manager.InstallMethod
+import dev.beefers.vendetta.manager.domain.manager.PreferenceManager
+import dev.beefers.vendetta.manager.installer.shizuku.ShizukuPermissions
 import dev.beefers.vendetta.manager.ui.screen.installer.InstallerScreen
 import dev.beefers.vendetta.manager.ui.screen.main.MainScreen
 import dev.beefers.vendetta.manager.ui.theme.VendettaManagerTheme
 import dev.beefers.vendetta.manager.utils.DiscordVersion
 import dev.beefers.vendetta.manager.utils.Intents
-import rikka.shizuku.Shizuku
+import org.koin.android.ext.android.inject
 
-
-class MainActivity : ComponentActivity(), Shizuku.OnRequestPermissionResultListener {
-
-    private val acRequestCode = 1
-    private val REQUEST_PERMISSION_RESULT_LISTENER = this::onRequestPermissionResult
-
-    override fun onRequestPermissionResult(requestCode: Int, grantResult: Int) {
-        if (grantResult != PackageManager.PERMISSION_GRANTED) {
-            checkAndRequestPermission()
-        }
-    }
-
-    private fun checkAndRequestPermission() {
-        if (Shizuku.pingBinder()) {
-            Shizuku.addRequestPermissionResultListener(REQUEST_PERMISSION_RESULT_LISTENER)
-            if (Shizuku.checkSelfPermission() != PackageManager.PERMISSION_GRANTED) {
-                Shizuku.requestPermission(acRequestCode)
-            }
-        }
-    }
+class MainActivity : ComponentActivity() {
+    private val preferences: PreferenceManager by inject()
 
     @OptIn(ExperimentalAnimationApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -52,7 +37,8 @@ class MainActivity : ComponentActivity(), Shizuku.OnRequestPermissionResultListe
             )
         }
 
-        checkAndRequestPermission()
+        if (preferences.installMethod == InstallMethod.SHIZUKU)
+            ShizukuPermissions.requestShizukuPermissions()
 
         val screen = if (intent.action == Intents.Actions.INSTALL && version != null) {
             InstallerScreen(DiscordVersion.fromVersionCode(version)!!)
@@ -68,10 +54,4 @@ class MainActivity : ComponentActivity(), Shizuku.OnRequestPermissionResultListe
             }
         }
     }
-
-    override fun onDestroy() {
-        Shizuku.removeRequestPermissionResultListener(REQUEST_PERMISSION_RESULT_LISTENER)
-        super.onDestroy()
-    }
-
 }

--- a/app/src/main/java/dev/beefers/vendetta/manager/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/ui/screen/settings/SettingsScreen.kt
@@ -1,6 +1,5 @@
 package dev.beefers.vendetta.manager.ui.screen.settings
 
-import android.content.pm.PackageManager
 import android.os.Build
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.rememberScrollState
@@ -12,7 +11,6 @@ import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,7 +39,6 @@ import dev.beefers.vendetta.manager.utils.ManagerTab
 import dev.beefers.vendetta.manager.utils.TabOptions
 import dev.beefers.vendetta.manager.utils.navigate
 import org.koin.androidx.compose.get
-import rikka.shizuku.Shizuku
 import java.io.File
 
 class SettingsScreen : ManagerTab {
@@ -58,17 +55,6 @@ class SettingsScreen : ManagerTab {
         val prefs: PreferenceManager = get()
         val installManager: InstallManager = get()
         val ctx = LocalContext.current
-        var shizukuAvailable by remember { mutableStateOf(false) }
-
-        LaunchedEffect(Unit) {
-            val shizukuAlive = Shizuku.pingBinder()
-            val shizukuPermissionsGranted = if (shizukuAlive) {
-                Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED
-            } else {
-                false
-            }
-            shizukuAvailable = shizukuAlive && shizukuPermissionsGranted
-        }
 
         Column(
             modifier = Modifier.verticalScroll(rememberScrollState())
@@ -148,10 +134,7 @@ class SettingsScreen : ManagerTab {
                 labelFactory = {
                     ctx.getString(it.labelRes)
                 },
-                disabled = !shizukuAvailable,
-                onPrefChange = {
-                    prefs.installMethod = it
-                }
+                onPrefChange = viewModel::setInstallMethod,
             )
             SettingsSwitch(
                 label = stringResource(R.string.settings_auto_clear_cache),

--- a/app/src/main/java/dev/beefers/vendetta/manager/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/ui/screen/settings/SettingsScreen.kt
@@ -224,4 +224,5 @@ class SettingsScreen : ManagerTab {
             )
         }
     }
+
 }

--- a/app/src/main/java/dev/beefers/vendetta/manager/ui/viewmodel/settings/SettingsViewModel.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/ui/viewmodel/settings/SettingsViewModel.kt
@@ -6,14 +6,20 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import cafe.adriel.voyager.core.model.ScreenModel
+import cafe.adriel.voyager.core.model.coroutineScope
 import dev.beefers.vendetta.manager.R
+import dev.beefers.vendetta.manager.domain.manager.InstallMethod
+import dev.beefers.vendetta.manager.domain.manager.PreferenceManager
 import dev.beefers.vendetta.manager.domain.manager.UpdateCheckerDuration
+import dev.beefers.vendetta.manager.installer.shizuku.ShizukuPermissions
 import dev.beefers.vendetta.manager.updatechecker.worker.UpdateWorker
 import dev.beefers.vendetta.manager.utils.showToast
+import kotlinx.coroutines.launch
 import java.io.File
 
 class SettingsViewModel(
-    private val context: Context
+    private val context: Context,
+    private val prefs: PreferenceManager,
 ) : ScreenModel {
     private val cacheDir = context.externalCacheDir ?: File(Environment.getExternalStorageDirectory(), Environment.DIRECTORY_DOWNLOADS).resolve("VendettaManager").also { it.mkdirs() }
 
@@ -37,4 +43,17 @@ class SettingsViewModel(
         }
     }
 
+    fun setInstallMethod(method: InstallMethod) {
+        when (method) {
+            InstallMethod.SHIZUKU -> coroutineScope.launch {
+                if (ShizukuPermissions.waitShizukuPermissions()) {
+                    prefs.installMethod = InstallMethod.SHIZUKU
+                } else {
+                    context.showToast(R.string.msg_shizuku_denied)
+                }
+            }
+
+            else -> prefs.installMethod = method
+        }
+    }
 }

--- a/app/src/main/java/dev/beefers/vendetta/manager/ui/viewmodel/settings/SettingsViewModel.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/ui/viewmodel/settings/SettingsViewModel.kt
@@ -56,4 +56,5 @@ class SettingsViewModel(
             else -> prefs.installMethod = method
         }
     }
+
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="msg_downgrade">Cannot downgrade, try uninstalling first</string>
     <string name="msg_unlocked">You are now a developer</string>
     <string name="msg_permission_grant">In order for Vendetta Manager to function, file permissions are required. Since shared data is stored in ~/Vendetta, permissions are required in order to access it.</string>
+    <string name="msg_shizuku_denied">Failed to obtain Shizuku permissions</string>
     <string name="msg_change_mirror">Would you like to try again using a download mirror?</string>
     <string name="msg_invalid_apk">APK was corrupted, try clearing cache then reinstalling</string>
 
@@ -139,6 +140,6 @@
     <string name="version_target">Target: %1$s</string>
     <string name="version_current">Current: %1$s</string>
     <string name="install_method">Install method</string>
-    <string name="default_installer">Default (recommended)</string>
+    <string name="default_installer">PackageManager (recommended)</string>
     <string name="shizuku_installer">Shizuku</string>
 </resources>


### PR DESCRIPTION
Fixes #58

- Only request shizuku at startup if shizuku is the selected install method (not by default)
- Request and wait for shizuku perms again once installing and handle the event that permissions are denied/not available
- When switching install methods, check if shizuku is available and wait for permissions to be granted before confirming the change (previously this relied on shizuku was already granted at startup otherwise it disabled the switcher)