### PR TITLE
feat(DownloadManager): properly handle downloading

### DIFF
--- a/app/src/main/java/dev/beefers/vendetta/manager/domain/manager/DownloadManager.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/domain/manager/DownloadManager.kt
@@ -109,14 +109,14 @@ class DownloadManager(
         }
     }
 
-    private fun getDownloadProgress(queryCursor: Cursor): Float {
+    private fun getDownloadProgress(queryCursor: Cursor): Float? {
         val bytesColumn = queryCursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)
         val bytes = queryCursor.getLong(bytesColumn)
 
         val totalBytesColumn = queryCursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES)
         val totalBytes = queryCursor.getLong(totalBytesColumn)
 
-        if (totalBytes <= 0) return 0f
+        if (totalBytes <= 0) return null
         return bytes.toFloat() / totalBytes
     }
 

--- a/app/src/main/java/dev/beefers/vendetta/manager/domain/manager/DownloadManager.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/domain/manager/DownloadManager.kt
@@ -130,8 +130,8 @@ class DownloadManager(
         DownloadManager.ERROR_DEVICE_NOT_FOUND -> "DEVICE_NOT_FOUND"
         DownloadManager.ERROR_CANNOT_RESUME -> "CANNOT_RESUME"
         DownloadManager.ERROR_FILE_ALREADY_EXISTS -> "FILE_ALREADY_EXISTS"
-        /* DownloadManager.ERROR_BLOCKED */ 1010 -> "DEVICE_NOT_FOUND"
-        else -> "Unknown error code"
+        /* DownloadManager.ERROR_BLOCKED */ 1010 -> "NETWORK_BLOCKED"
+        else -> "UNKNOWN_CODE"
     }
 
 }

--- a/app/src/main/java/dev/beefers/vendetta/manager/domain/manager/DownloadManager.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/domain/manager/DownloadManager.kt
@@ -1,33 +1,32 @@
 package dev.beefers.vendetta.manager.domain.manager
 
 import android.app.DownloadManager
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.database.Cursor
 import android.net.Uri
-import android.os.Environment
+import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.request.prepareGet
-import io.ktor.http.contentLength
-import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.jvm.javaio.toInputStream
+import dev.beefers.vendetta.manager.ui.activity.MainActivity
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import java.io.File
-import java.io.InputStream
-import java.io.OutputStream
 
 class DownloadManager(
     private val context: Context,
     private val prefs: PreferenceManager
 ) {
 
-    suspend fun downloadDiscordApk(version: String, out: File, onProgressUpdate: (Float) -> Unit): File =
+    suspend fun downloadDiscordApk(version: String, out: File, onProgressUpdate: (Float?) -> Unit): DownloadResult =
         download("${prefs.mirror.baseUrl}/tracker/download/$version/base", out, onProgressUpdate)
 
-    suspend fun downloadSplit(version: String, split: String, out: File, onProgressUpdate: (Float) -> Unit): File =
+    suspend fun downloadSplit(version: String, split: String, out: File, onProgressUpdate: (Float?) -> Unit): DownloadResult =
         download("${prefs.mirror.baseUrl}/tracker/download/$version/$split", out, onProgressUpdate)
 
-    suspend fun downloadVendetta(out: File, onProgressUpdate: (Float) -> Unit) =
+    suspend fun downloadVendetta(out: File, onProgressUpdate: (Float?) -> Unit) =
         download(
             "https://github.com/vendetta-mod/VendettaXposed/releases/latest/download/app-release.apk",
             out,
@@ -42,48 +41,140 @@ class DownloadManager(
             /* TODO: Update a progress bar in the update dialog */
         }
 
-    suspend fun download(url: String, out: File, onProgressUpdate: (Float) -> Unit): File {
-        val request = DownloadManager.Request(Uri.parse(url))
+    /**
+     * Start a cancellable download with the system [DownloadManager].
+     * If the current [CoroutineScope] is cancelled, then the system download will be cancelled
+     * almost immediately.
+     * @param url Remote src url
+     * @param out Target path to download to
+     * @param onProgressUpdate Download progress update in a `[0,1]` range, and if null then the
+     *                         download is currently in a pending state. This is called every 100ms.
+     */
+    suspend fun download(
+        url: String,
+        out: File,
+        onProgressUpdate: (Float?) -> Unit
+    ): DownloadResult {
+        val downloadManager = context.getSystemService<DownloadManager>()
+            ?: throw IllegalStateException("DownloadManager service is not available")
+
+        val downloadId = DownloadManager.Request(Uri.parse(url))
             .setTitle("Vendetta Manager")
             .setDescription("Downloading ${out.name}...")
             .setDestinationUri(Uri.fromFile(out))
             .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE)
             .setAllowedOverMetered(true)
             .setAllowedOverRoaming(true)
+            .let(downloadManager::enqueue)
 
-        val downloadManager = context.getSystemService<DownloadManager>()
-            ?: throw IllegalStateException("DownloadManager not available")
+        // Notification click listener to re-open VD
+        val clickReceiver = DownloadClickReceiver(downloadId)
+        ContextCompat.registerReceiver(
+            context,
+            clickReceiver,
+            IntentFilter(DownloadManager.ACTION_NOTIFICATION_CLICKED),
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
 
-        val downloadId = downloadManager.enqueue(request)
-
-        var lastProgress = 0L
-
+        // Repeatedly request download state until it is finished
         while (true) {
-            val query = DownloadManager.Query().setFilterById(downloadId)
-            val cursor = downloadManager.query(query)
+            try {
+                // Hand over control to a suspend function to check for cancellation
+                delay(100)
+            } catch (_: CancellationException) {
+                // If the running CoroutineScope has been cancelled, then gracefully cancel download
+                context.unregisterReceiver(clickReceiver)
+                downloadManager.remove(downloadId)
+                return DownloadResult.Cancelled(systemTriggered = false)
+            }
 
-            if (cursor.moveToFirst()) {
-                val status = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_STATUS))
-                if (status == DownloadManager.STATUS_SUCCESSFUL) {
-                    break
-                } else if (status == DownloadManager.STATUS_FAILED) {
-                    // Handle download failure
-                    break
-                } else {
-                    val bytesDownloaded = cursor.getLong(cursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR))
-                    val bytesTotal = cursor.getLong(cursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES))
-                    val progress = if (bytesTotal > 0) bytesDownloaded * 100 / bytesTotal else 0
+            // Request download status
+            val cursor = DownloadManager.Query()
+                .setFilterById(downloadId)
+                .let(downloadManager::query)
 
-                    if (progress > lastProgress) {
-                        onProgressUpdate(progress.toFloat() / 100f) // Corrected progress calculation
-                        lastProgress = progress
+            // No results in cursor, download was cancelled
+            if (!cursor.moveToFirst()) {
+                cursor.close()
+                context.unregisterReceiver(clickReceiver)
+                return DownloadResult.Cancelled(systemTriggered = true)
+            }
+
+            val statusColumn = cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)
+            val status = cursor.getInt(statusColumn)
+
+            cursor.use {
+                when (status) {
+                    DownloadManager.STATUS_PENDING, DownloadManager.STATUS_PAUSED ->
+                        onProgressUpdate(null)
+
+                    DownloadManager.STATUS_RUNNING ->
+                        onProgressUpdate(getDownloadProgress(cursor))
+
+                    DownloadManager.STATUS_SUCCESSFUL -> {
+                        cursor.close()
+                        context.unregisterReceiver(clickReceiver)
+                        return DownloadResult.Success
+                    }
+
+                    DownloadManager.STATUS_FAILED -> {
+                        val reasonColumn = cursor.getColumnIndex(DownloadManager.COLUMN_REASON)
+                        val reason = cursor.getInt(reasonColumn)
+
+                        context.unregisterReceiver(clickReceiver)
+                        return DownloadResult.Error(debugReason = convertErrorCode(reason))
                     }
                 }
             }
-            cursor.close()
         }
-
-        return out
     }
 
+    private fun getDownloadProgress(queryCursor: Cursor): Float {
+        val bytesColumn = queryCursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)
+        val bytes = queryCursor.getLong(bytesColumn)
+
+        val totalBytesColumn = queryCursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES)
+        val totalBytes = queryCursor.getLong(totalBytesColumn)
+
+        if (totalBytes <= 0) return 0f
+        return bytes.toFloat() / totalBytes
+    }
+
+    private fun convertErrorCode(code: Int) = when (code) {
+        DownloadManager.ERROR_UNKNOWN -> "UNKNOWN"
+        DownloadManager.ERROR_FILE_ERROR -> "FILE_ERROR"
+        DownloadManager.ERROR_UNHANDLED_HTTP_CODE -> "UNHANDLED_HTTP_CODE"
+        DownloadManager.ERROR_HTTP_DATA_ERROR -> "HTTP_DATA_ERROR"
+        DownloadManager.ERROR_TOO_MANY_REDIRECTS -> "TOO_MANY_REDIRECTS"
+        DownloadManager.ERROR_INSUFFICIENT_SPACE -> "INSUFFICIENT_SPACE"
+        DownloadManager.ERROR_DEVICE_NOT_FOUND -> "DEVICE_NOT_FOUND"
+        DownloadManager.ERROR_CANNOT_RESUME -> "CANNOT_RESUME"
+        DownloadManager.ERROR_FILE_ALREADY_EXISTS -> "FILE_ALREADY_EXISTS"
+        /* DownloadManager.ERROR_BLOCKED */ 1010 -> "DEVICE_NOT_FOUND"
+        else -> "Unknown error code"
+    }
+
+}
+
+private class DownloadClickReceiver(
+    private val targetDownloadId: Long,
+) : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val downloadId = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1)
+
+        if (targetDownloadId != downloadId)
+            return
+
+        val launchIntent = Intent(context, MainActivity::class.java)
+        context.unregisterReceiver(this)
+        context.startActivity(launchIntent)
+    }
+
+}
+
+sealed interface DownloadResult {
+    object Success : DownloadResult
+    data class Cancelled(val systemTriggered: Boolean) : DownloadResult
+    data class Error(val debugReason: String) : DownloadResult
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,8 @@
     <string name="msg_shizuku_denied">Failed to obtain Shizuku permissions</string>
     <string name="msg_change_mirror">Would you like to try again using a download mirror?</string>
     <string name="msg_invalid_apk">APK was corrupted, try clearing cache then reinstalling</string>
+    <string name="msg_download_cancelled">Download was aborted</string>
+    <string name="msg_download_failed">Download failed</string>
 
     <string name="group_download">Download APKs</string>
     <string name="group_patch">Patching</string>


### PR DESCRIPTION
This rewrites the download manager to properly handle all possible download states, and cancel/clean up after itself properly (previously it could get in a stuck state and hang a thread forever, lagging the device from download state queries every millisecond)

Additionally, this handles the event the download was cancelled through a coroutine cancellation, and cancels the download subsequently and cleans up after itself (so the entire installation process will not go on now either)

Could possibly be a fix for #50 as well