### PR TITLE
Allow other module repositories

### DIFF
--- a/app/src/main/java/dev/beefers/vendetta/manager/domain/manager/PreferenceManager.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/domain/manager/PreferenceManager.kt
@@ -44,6 +44,8 @@ class PreferenceManager(context: Context) :
 
     var moduleLocation by filePreference("module_location", DEFAULT_MODULE_LOCATION)
 
+    var vendettaModuleRepo by stringPreference("vendetta_module_repo", "vendetta-mod/VendettaXposed")
+
     var installMethod by enumPreference("install_method", InstallMethod.DEFAULT)
 
     var logsAlternateBackground by booleanPreference("logs_alternate_bg", true)

--- a/app/src/main/java/dev/beefers/vendetta/manager/installer/step/download/DownloadVendettaStep.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/installer/step/download/DownloadVendettaStep.kt
@@ -17,7 +17,7 @@ class DownloadVendettaStep(
 
     override val nameRes = R.string.step_dl_vd
 
-    override val url: String = "https://github.com/vendetta-mod/VendettaXposed/releases/latest/download/app-release.apk"
+    override val url: String = "https://github.com/${preferenceManager.vendettaModuleRepo}/releases/latest/download/app-release.apk"
     override val destination = preferenceManager.moduleLocation
     override val workingCopy = workingDir.resolve("vendetta.apk")
 

--- a/app/src/main/java/dev/beefers/vendetta/manager/network/service/RestService.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/network/service/RestService.kt
@@ -16,7 +16,7 @@ class RestService(
 
     suspend fun getLatestRelease(repo: String) = withContext(Dispatchers.IO) {
         httpService.request<Release> {
-            url("https://api.github.com/repos/vendetta-mod/$repo/releases/latest")
+            url("https://api.github.com/repos/$repo/releases/latest")
         }
     }
 
@@ -28,7 +28,7 @@ class RestService(
 
     suspend fun getCommits(repo: String, page: Int = 1) = withContext(Dispatchers.IO) {
         httpService.request<List<Commit>> {
-            url("https://api.github.com/repos/vendetta-mod/$repo/commits")
+            url("https://api.github.com/repos/$repo/commits")
             parameter("page", page)
         }
     }

--- a/app/src/main/java/dev/beefers/vendetta/manager/network/utils/CommitsPagingSource.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/network/utils/CommitsPagingSource.kt
@@ -2,11 +2,13 @@ package dev.beefers.vendetta.manager.network.utils
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import dev.beefers.vendetta.manager.domain.manager.PreferenceManager
 import dev.beefers.vendetta.manager.domain.repository.RestRepository
 import dev.beefers.vendetta.manager.network.dto.Commit
 
 class CommitsPagingSource(
-    private val repo: RestRepository
+    private val repo: RestRepository,
+    private val prefs: PreferenceManager
 ) : PagingSource<Int, Commit>() {
 
     override fun getRefreshKey(state: PagingState<Int, Commit>): Int? =
@@ -17,7 +19,7 @@ class CommitsPagingSource(
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Commit> {
         val page = params.key ?: 0
 
-        return when (val response = repo.getCommits("vendetta-mod/Vendetta", page)) {
+        return when (val response = repo.getCommits(prefs.vendettaModuleRepo, page)) {
             is ApiResponse.Success -> LoadResult.Page(
                 data = response.data,
                 prevKey = if (page > 0) page - 1 else null,

--- a/app/src/main/java/dev/beefers/vendetta/manager/network/utils/CommitsPagingSource.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/network/utils/CommitsPagingSource.kt
@@ -17,7 +17,7 @@ class CommitsPagingSource(
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Commit> {
         val page = params.key ?: 0
 
-        return when (val response = repo.getCommits("Vendetta", page)) {
+        return when (val response = repo.getCommits("vendetta-mod/Vendetta", page)) {
             is ApiResponse.Success -> LoadResult.Page(
                 data = response.data,
                 prevKey = if (page > 0) page - 1 else null,

--- a/app/src/main/java/dev/beefers/vendetta/manager/ui/screen/settings/DeveloperSettings.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/ui/screen/settings/DeveloperSettings.kt
@@ -116,6 +116,13 @@ class DeveloperSettings: Screen {
                 )
 
                 SettingsTextField(
+                    label = stringResource(R.string.settings_vendetta_module_repo),
+                    supportingText = stringResource(R.string.settings_vendetta_module_repo_description),
+                    pref = prefs.vendettaModuleRepo,
+                    onPrefChange = { prefs.vendettaModuleRepo = it }
+                )
+
+                SettingsTextField(
                     label = stringResource(R.string.settings_module_location),
                     supportingText = stringResource(R.string.settings_module_location_description),
                     pref = moduleLocation,

--- a/app/src/main/java/dev/beefers/vendetta/manager/ui/viewmodel/home/HomeViewModel.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/ui/viewmodel/home/HomeViewModel.kt
@@ -107,11 +107,11 @@ class HomeViewModel(
 
     private fun checkForUpdate() {
         screenModelScope.launch {
-            release = repo.getLatestRelease("VendettaManager").dataOrNull
+            release = repo.getLatestRelease("vendetta-mod/VendettaManager").dataOrNull
             release?.let {
                 showUpdateDialog = it.tagName.toInt() > BuildConfig.VERSION_CODE
             }
-            repo.getLatestRelease("VendettaXposed").ifSuccessful {
+            repo.getLatestRelease(prefs.vendettaModuleRepo).ifSuccessful {
                 if (prefs.moduleVersion != it.tagName) {
                     prefs.moduleVersion = it.tagName
                     val module = File(cacheDir, "vendetta.apk")

--- a/app/src/main/java/dev/beefers/vendetta/manager/ui/viewmodel/home/HomeViewModel.kt
+++ b/app/src/main/java/dev/beefers/vendetta/manager/ui/viewmodel/home/HomeViewModel.kt
@@ -52,7 +52,7 @@ class HomeViewModel(
 
     var showUpdateDialog by mutableStateOf(false)
     var isUpdating by mutableStateOf(false)
-    val commits = Pager(PagingConfig(pageSize = 30)) { CommitsPagingSource(repo) }.flow.cachedIn(screenModelScope)
+    val commits = Pager(PagingConfig(pageSize = 30)) { CommitsPagingSource(repo, prefs) }.flow.cachedIn(screenModelScope)
 
     init {
         getDiscordVersions()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,8 @@
     <string name="settings_module_location_reset">Reset module location</string>
     <string name="settings_package_name">Package name</string>
     <string name="settings_version">Discord version</string>
+    <string name="settings_vendetta_module_repo">Vendetta module repo</string>
+    <string name="settings_vendetta_module_repo_description">The repository to download the Vendetta module from</string>
     <string name="settings_debuggable">Debuggable</string>
     <string name="settings_debuggable_description">Enable debuggable flag</string>
 


### PR DESCRIPTION
# About 

This PR does two things.

1. It adds a developer setting to specify the module repository for Vendetta
   <img width="959" alt="image" src="https://github.com/vendetta-mod/VendettaManager/assets/13122796/47945ad5-d064-41e0-b300-beecc1769889">

3. It displays commits for the module repository instead of non-Xposed Vendetta. This makes sense because actual changes happen there

## Why

Because Vendetta is now discontinued, this app can be repurposed in a certain way which prevents it to be useless when the module it injects is discontinued. Firstival is everyone that wants to create their own module required to fork this app. This means splitting the user base between the upstream version and all the other forkers. Second, if a forker discontinues their module, it means the death of their forked Vendetta Manager app.

With this PR both issues are solved. No one has to fork this app, this means users can get updates and don't have to hop to forked versions. Neither is the user forced to switch apps is a forker discontinues a module in the future. This PR ensures that the app can be useful for the future without turning useless just because the module is discontinued, by making the app modular  and agnostic to the module it injects. This flexibility can be extended in the future to reduce the need to fork to a minimum.